### PR TITLE
feat(tasks): adding tasks.json as a default

### DIFF
--- a/packages/tasks/specs/TaskBuilder.spec.ts
+++ b/packages/tasks/specs/TaskBuilder.spec.ts
@@ -9,15 +9,15 @@ const assets = fs.join(__dirname, 'assets')
 
 describe('when using TaskBuilder', () => {
   it('should create builder', () => {
-    expect(() => new TaskBuilder(assets, 'tasks.json')).to.not.throw
+    expect(() => TaskBuilder.from(assets)).to.not.throw
   })
 
   it('should fail to create when tasks not found', () => {
-    expect(() => new TaskBuilder(assets, 'undefined.json')).to.throw
+    expect(() => new TaskBuilder(assets, ['undefined.json'])).to.throw
   })
 
   describe('to compile tasks', () => {
-    const builder = new TaskBuilder(assets, 'tasks.json')
+    const builder = TaskBuilder.from(assets)
 
     it('should compile tasks', async () => {
       const config = await builder.build()

--- a/packages/tasks/specs/TaskRunner.spec.ts
+++ b/packages/tasks/specs/TaskRunner.spec.ts
@@ -4,19 +4,12 @@ import { fs } from '@nofrills/fs'
 
 import expect from './expect'
 
-import {
-  TaskConfig,
-  TaskBuilder,
-  TaskRunner,
-  TaskJobs,
-  TaskJobResult,
-  TaskRunnerAdapter,
-} from '../src/index'
+import { TaskConfig, TaskBuilder, TaskRunner, TaskJobs, TaskJobResult, TaskRunnerAdapter } from '../src/index'
 
 const assets = fs.join(__dirname, 'assets')
 
 describe('when using TaskRunner', () => {
-  const builder = new TaskBuilder(assets, 'tasks.json')
+  const builder = TaskBuilder.from(assets)
 
   const TestTask: TaskConfig = {
     tasks: {
@@ -30,12 +23,8 @@ describe('when using TaskRunner', () => {
     },
   }
 
-  const adapter: TaskRunnerAdapter = (
-    task: TaskJobs,
-  ): Promise<TaskJobResult[]> => {
-    return Promise.all(
-      task.jobs.map(job => ({ code: 0, job, messages: [], signal: null })),
-    )
+  const adapter: TaskRunnerAdapter = (task: TaskJobs): Promise<TaskJobResult[]> => {
+    return Promise.all(task.jobs.map(job => ({ code: 0, job, messages: [], signal: null })))
   }
 
   it('should execute tasks', async () => {

--- a/packages/tasks/src/TaskBuilder.ts
+++ b/packages/tasks/src/TaskBuilder.ts
@@ -18,11 +18,11 @@ export class TaskBuilder {
   private readonly log: Lincoln = Logger.extend('builder')
   private readonly resolver: FileResolver
 
-  constructor(public readonly cwd: string, private readonly definitions: string = 'package.json') {
+  constructor(public readonly cwd: string, private readonly definitions: string[]) {
     this.resolver = CreateResolver(cwd)
   }
 
-  static from(cwd: string, definitions: string = 'package.json'): TaskBuilder {
+  static from(cwd: string, definitions: string[] = ['tasks.json', 'package.json']): TaskBuilder {
     return new TaskBuilder(cwd, definitions)
   }
 
@@ -85,8 +85,9 @@ export class TaskBuilder {
     return context
   }
 
-  protected resolve(): Promise<string[]> {
-    return this.resolver.find(this.definitions)
+  protected async resolve(): Promise<string[]> {
+    const found = await Promise.all(this.definitions.map(definition => this.resolver.find(definition)))
+    return found.reduce((results, current) => results.concat(...current), [])
   }
 
   protected transform(config: TaskConfig): TaskConfig {


### PR DESCRIPTION
affects: @nofrills/tasks

BREAKING CHANGE:
TaskBuilder no longer takes a string, but rather a string[]